### PR TITLE
Follow symlinks to set root

### DIFF
--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -56,7 +56,12 @@
   "Save the current buffer in a variable to serve to the server."
   (setq org-roam-server-current-buffer (window-buffer)))
 
-(defvar org-roam-server-root (concat (file-name-directory (or load-file-name buffer-file-name)) "."))
+(defvar org-roam-server-root
+  (concat (file-name-directory
+           (file-truename (or
+                           load-file-name
+                           buffer-file-name)))
+          "."))
 (setq httpd-root org-roam-server-root)
 
 (defun org-roam-server-html-servlet (file)


### PR DESCRIPTION
This fixes a problem where the server wouldn't find any of the assets when installing org-roam-server via straight.el, as straight loads org-roam-server from:

`~/.emacs.d/local/straight/build/org-roam-server/org-roam-server.el`

Which is a symlink to the real file, located here:

`~/.emacs.d/local/straight/repos/org-roam-server/org-roam-server.el`

(Paths taken from my setup on Doom emacs)

This fix allows me to install `org-roam-server` this way on Doom emacs:

In `.doom.d/packages.el`:

```elisp
(package! simple-httpd)
(package! org-roam-server
  :recipe (:host github :repo "org-roam/org-roam-server"))
```

In `.doom.d/config.el`:

```elisp
(use-package! org-roam-server)
```