### PR TITLE
Update link to org-roam protocol installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The graph utilizes org-roam protocol which means if you click on one
 of the nodes, it will open the corresponding file in Emacs. For this
 feature to work, org-roam protocol should be configured in the system.
 
-[Configuring Org-Roam Protocol](https://org-roam.readthedocs.io/en/develop/roam_protocol/)
+[Configuring Org-Roam Protocol](https://org-roam.github.io/org-roam/manual/Installation-_00281_0029.html)
 
 Also make sure the emacs server is started; `M-x server-start RET`
 


### PR DESCRIPTION
org-roam documentation has changed location

I'm pretty sure this new link will be a permalink (not certain though)