### PR TITLE
Fix node query

### DIFF
--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -303,7 +303,7 @@ DESCRIPTION is the shown attribute to the user."
           (httpd-error httpd-current-proc 403)))
   (let* ((node-query `[:select [titles:file titles tags] :from titles
                                :left :outer :join tags :on (= titles:file tags:file)
-                               ,@(org-roam-graph--expand-matcher 'titles:file t) ])
+                               ,@(org-roam-graph--expand-matcher 'titles:file t)])
          (data (org-roam-server-visjs-json node-query)))
     (when (or force (not (string= data org-roam-server-data)))
       (setq org-roam-server-data data)

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -302,8 +302,8 @@ DESCRIPTION is the shown attribute to the user."
       (if (not (string= org-roam-server-token token))
           (httpd-error httpd-current-proc 403)))
   (let* ((node-query `[:select [titles:file titles tags] :from titles
-                               ,@(org-roam-graph--expand-matcher 'file t)
-                               :left :outer :join tags :on (= titles:file tags:file)])
+                               :left :outer :join tags :on (= titles:file tags:file)
+                               ,@(org-roam-graph--expand-matcher 'titles:file t) ])
          (data (org-roam-server-visjs-json node-query)))
     (when (or force (not (string= data org-roam-server-data)))
       (setq org-roam-server-data data)


### PR DESCRIPTION
I am getting an emacsql error with the current version, probably because the rendered query has the `LEFT JOIN` after the `WHERE` clause - this fixes it