### PR TITLE
Read back localStorage value as string

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
           }
 
           var darkmode;
-          if (localStorage.darkmode) {
+          if (localStorage.darkmode === "true") {
               $('#colormode-checkbox').bootstrapToggle('on')
           } else {
               $('#colormode-checkbox').bootstrapToggle('off')


### PR DESCRIPTION
Since `localStorage` stores everything as a string, `localStorage.darkmode` is always true, even if the value is `false` - instead we should check for equality with `"true"`