### PR TITLE
Fix call to changed org-roam--with-temp-buffer function

### DIFF
--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -163,7 +163,7 @@ This is added as a hook to `org-capture-after-finalize-hook'."
 (defun org-roam-server-visjs-json (node-query)
   "Convert `org-roam` NODE-QUERY db query to the visjs json format."
   (org-roam-db--ensure-built)
-  (org-roam--with-temp-buffer
+  (org-roam--with-temp-buffer nil
     (let* ((nodes (org-roam-db-query node-query))
            (edges-query
             `[:with selected :as [:select [file] :from ,node-query]
@@ -311,7 +311,7 @@ DESCRIPTION is the shown attribute to the user if the image is not rendered."
     (httpd-start)
     (let ((node-query `[:select [file titles] :from titles
                                 ,@(org-roam-graph--expand-matcher 'file t)]))
-      (org-roam--with-temp-buffer
+      (org-roam--with-temp-buffer nil
         (let ((nodes (org-roam-db-query node-query)))
           (dotimes (idx (length nodes))
             (let ((file (xml-escape-string (car (elt nodes idx)))))


### PR DESCRIPTION
The function now expects `file` as the first argument, so I was getting the error:

```
(file-error "Opening input file" "File name too long" "/home/alex/{\"nodes\":[{\"id\":\"...")
```

Because it treated the body as the file path.

The changed was introduced in this commit https://github.com/org-roam/org-roam/commit/1756ec6441f7d2016682b7e22bc9370bdca56bb7