### PR TITLE
Handle the URL with parent directories

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,7 +688,10 @@
                   string = string.substring(0, string.lastIndexOf('.'));
                   let link;
                   for (let i = 0; i < select2Data.length; i++) {
-                      if (select2Data[i].id === string) {
+                      // handle the URLs of select2Data[i] with parent directories
+                      let selstr = select2Data[i].id;
+                      selstr = selstr.substring(selstr.lastIndexOf('/')+1);
+                      if (selstr === string) {
                           link = `org-roam-buffer?path=${select2Data[i].path}&` +
                               `label=${select2Data[i].text}&token=${token}`;
                           break


### PR DESCRIPTION
In my org project, there are sub-directories. The backlinks won't show due to them. So in this PR, the sub-directories are handled.

Here is the debug info:
```
Load is triggered on #filenode
(index):688 The original string is http://localhost:8080/2020/2020-11-monthly.html?token=null
(index):690 The filtered (v1) string is 2020-11-monthly.html?token=null
(index):692 The filtered (v2) string is 2020-11-monthly
(index):695 select2Data[0]: index
(index):695 select2Data[1]: kb/roam
(index):695 select2Data[2]: kb/python
(index):695 select2Data[3]: kb/note_taking_app
(index):695 select2Data[4]: kb/geant4
(index):695 select2Data[5]: 2020/2020-weekly
(index):695 select2Data[6]: 2020/2020-11-monthly
```` 