### PR TITLE
Bugfix: Handle org-roam-server-db-last-modification as a float to avoid integer overflows.

### DIFF
--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -66,9 +66,9 @@
           "."))
 
 (defvar org-roam-server-db-last-modification
-  (floor (float-time
-          (file-attribute-modification-time
-           (file-attributes org-roam-db-location)))))
+  (float-time
+   (file-attribute-modification-time
+    (file-attributes org-roam-db-location))))
 
 (defgroup org-roam-server nil
   "org-roam-server customizable variables."
@@ -526,15 +526,16 @@ DESCRIPTION is the shown attribute to the user if the image is not rendered."
         (insert (format "data: %s\n\n"
                         (org-roam-server-visjs-json node-query)))
       (when (and org-roam-server-network-poll
-                 (not (eq org-roam-server-db-last-modification
-                          (floor (float-time
-                                  (file-attribute-modification-time
-                                   (file-attributes org-roam-db-location)))))))
+                 (> (abs (- org-roam-server-db-last-modification
+                              (float-time
+                               (file-attribute-modification-time
+				(file-attributes org-roam-db-location)))))
+		    1e-6))
         (let ((data (org-roam-server-visjs-json node-query)))
           (setq org-roam-server-db-last-modification
-                (floor (float-time
+                (float-time
                         (file-attribute-modification-time
-                         (file-attributes org-roam-db-location)))))
+                         (file-attributes org-roam-db-location))))
           (insert (format "data: %s\n\n" data)))))))
 
 (defservlet* network-vis-options application/json (token)


### PR DESCRIPTION
motivation: org-roam-server was not working on a Raspberry Pi due to an overflow.

On some architectures (e.g. armv7l), the use of 'floor' was raising an exception as the float-time value was too large to be converted into an integer.
Emacs actually only guarantees 28 bits for an integer [0].
This modification bypasses this issue by handling the org-roam-server-db-last-modification as a float.

[0] https://ftp.gnu.org/old-gnu/Manuals/elisp-manual-21-2.8/html_node/elisp_58.html