### PR TITLE
Add variable for default darkmode and default preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,7 +405,17 @@
               function () {previewFrame.style.display = "none";});
 
           var darkmode;
-          if (localStorage.darkmode === "true") {
+
+          $.ajax({
+            async: false,
+            type: 'GET',
+            url: `/default-darkmode?token=${token}`,
+              success : function(data) {
+                  darkmode = data.darkmode;
+              }
+          });
+
+          if (localStorage.darkmode === "true" || darkmode) {
               $('#colormode-checkbox').bootstrapToggle('on')
           } else {
               $('#colormode-checkbox').bootstrapToggle('off')

--- a/index.html
+++ b/index.html
@@ -519,6 +519,16 @@
 
           var currentNode;
           var preview = false;
+	
+         $.ajax({
+            async: false,
+            type: 'GET',
+            url: `/default-preview?token=${token}`,
+              success : function(data) {
+                  preview = data.preview;
+              }
+          });
+
 
           var currentBuffer;
           var oldCurrentBufferData = "";

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -200,6 +200,12 @@ or [{ \"id\": \"test\", \"parent\" : \"tags\"  }]"
   :group 'org-roam-server
   :type 'boolean)
 
+(defcustom org-roam-server-default-darkmode nil
+  "Enable or disable preview of notes by default.
+Default: nil"
+  :group 'org-roam-server
+  :type 'boolean)
+
 (define-obsolete-variable-alias 'org-roam-server-label-wrap-length
   'org-roam-server-network-label-wrap-length "org-roam-server 1.0.3")
 (define-obsolete-variable-alias 'org-roam-server-label-truncate
@@ -564,6 +570,13 @@ DESCRIPTION is the shown attribute to the user if the image is not rendered."
   (insert (format "{\"include\" : %s, \"exclude\": %s}"
                   org-roam-server-default-include-filters
                   org-roam-server-default-exclude-filters)))
+
+(defservlet* default-darkmode application/json (token)
+  (if org-roam-server-authenticate
+      (if (not (string= org-roam-server-token token))
+          (httpd-error httpd-current-proc 403)))
+  (insert (if org-roam-server-default-darkmode "{ \"darkmode\" : true}" "{ \"darkmode\" : false}"))
+)
 
 (defun org-roam-server-insert-title (title)
   "Insert the TITLE as `org-document-title`."

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -206,6 +206,12 @@ Default: nil"
   :group 'org-roam-server
   :type 'boolean)
 
+(defcustom org-roam-server-default-preview nil
+  "Enable or disable preview of notes by default.
+Default: nil"
+  :group 'org-roam-server
+  :type 'boolean)
+
 (define-obsolete-variable-alias 'org-roam-server-label-wrap-length
   'org-roam-server-network-label-wrap-length "org-roam-server 1.0.3")
 (define-obsolete-variable-alias 'org-roam-server-label-truncate
@@ -577,6 +583,14 @@ DESCRIPTION is the shown attribute to the user if the image is not rendered."
           (httpd-error httpd-current-proc 403)))
   (insert (if org-roam-server-default-darkmode "{ \"darkmode\" : true}" "{ \"darkmode\" : false}"))
 )
+
+(defservlet* default-preview application/json (token)
+  (if org-roam-server-authenticate
+      (if (not (string= org-roam-server-token token))
+          (httpd-error httpd-current-proc 403)))
+  (insert (if org-roam-server-default-preview "{ \"preview\" : true}" "{ \"preview\" : false}"))
+)
+
 
 (defun org-roam-server-insert-title (title)
   "Insert the TITLE as `org-document-title`."


### PR DESCRIPTION
Pull request to solve #92, adds an option to set a variable called `org-roam-server-default-darkmode`, which if set to `t` will always toggle darkmode when the server starts, regardless of cookies set.

The second pull commit adds the option to set a variable called `org-roam-server-default-preview`, which if set to `t` will enable preview by default, to solve #134.

The latter does work a bit janky though, as it does not yet change the text or state of the preview button, but this is remedied when the `Enable Preview` button is pressed once.

Also they are two different AJAX calls and functions at the moment, ideally all these settings would only require a single one of course.

Apologies for the possibly somewhat sloppy code, I'm rather new to elisp.