### PR TITLE
fix bugs for edit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,7 @@
                   for (let i = 0; i < select2Data.length; i++) {
                       if (select2Data[i].id === string) {
                           window.open("org-protocol://roam-file?file="
-                                      .concat(select2Data[i].path),
+                                      .concat(encodeURIComponent(select2Data[i].path)),
                                       "_self");
                           break
                       }


### PR DESCRIPTION
When clicking the edit button, there will be an error due to the roam-file path is not encoded in version 26.3 of GNU Emacs.