### PR TITLE
Dashes option and general options to cite edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,13 @@
     <link rel="stylesheet" href="assets/bootstrap.min.css">
     <link rel="stylesheet" href="assets/bootstrap-toggle.min.css">
     <link rel="stylesheet" href="assets/select2.min.css">
+    <link rel="stylesheet" type="text/css" href="/assets/tweaks.css">
     <script type="text/javascript" src="assets/jquery-3.5.0.min.js"></script>
     <script type="text/javascript" src="assets/vis-network.min.js"></script>
     <script type="text/javascript" src="assets/bootstrap.min.js"></script>
     <script type="text/javascript" src="assets/select2.min.js"></script>
     <script type="text/javascript" src="assets/bootstrap-toggle.min.js"></script>
+    
 
     <style type="text/css">
       * { padding: 0; margin: 0; }
@@ -123,6 +125,12 @@
           width: %50
       }
 
+     #toggle-tweaks {
+         position: relative;
+         float: left;
+         width: %50;
+     }
+
       #debug-button {
           display: none;
           position: absolute;
@@ -162,14 +170,16 @@
           background-color: #1d1e20;
           color: #c7cec6 ;
       }
+     
+     
     </style>
   </head>
 
   <body>
     <div id="dropdownfiles">
-      <select class="dropdownfiles" name="files" style="width: 100%;">
-        <option></option>
-      </select>
+     <select class="dropdownfiles" name="files" style="width: 100%;">
+       <option></option>
+     </select>
     </div>
     <div class="box" id="preview-frame">
       <button class="btn btn-link float-left"
@@ -210,7 +220,11 @@
     <button class="btn btn-sm btn-primary btn-simple" id="toggle-preview">
       Enable Preview
     </button>
-
+    
+    <button class="btn btn-sm btn-primary btn-simple" id="toggle-tweaks">
+      Show Tweaks
+    </button>
+    
     <div id="controls">
       <div id="dropdownfilters">
         <select class="dropdownfilters" name="tags"
@@ -252,6 +266,9 @@
       <iframe src="" id="filenode"></iframe>
       <iframe src="" id="backlinks"></iframe>
     </div>
+
+    
+    <div id="config"></config>
 
     <script type="text/javascript">
 
@@ -424,6 +441,9 @@
                   if ($("#buffer-network").css("display") === "block") {
                       bufferNetwork.setOptions({nodes: {font: { color: "#c7cec6" }}});
                   }
+                  $(".vis-config-s2").css("background-color", "#3d3d3d");
+                  $(".vis-config-s3").css("background-color", "#1f1f1f");
+                  $("#config").css("background-color", "#2e2e2e");
               } else {
                   $(document.body).removeClass("darkmode");
                   document.body.style.backgroundColor = "white";
@@ -436,6 +456,9 @@
                   if ($("#buffer-network").css("display") === "block") {
                       bufferNetwork.setOptions({nodes: {font: { color: "black" }}});
                   }
+                  $(".vis-config-s2").css("background-color", "#f7f8fa");
+                  $(".vis-config-s3").css("background-color", "#e4e9f0");
+                  $("#config").css("background-color", "#f1f1f1");
               }
           })
 
@@ -443,9 +466,26 @@
           var options = $.extend(true, {
               nodes: {shape: "dot"},
               interaction: {hover: true},
-              layout: {improvedLayout: true}
+              layout: {improvedLayout: true},
           }, customNetworkOptions);
 
+          var configoptions = $.extend(true, {
+         configure: {
+        filter: function (option, path) {
+              if (path.indexOf("physics") !== -1) {
+                return true;
+              }
+              if (path.indexOf("smooth") !== -1 || option === "smooth") {
+                return true;
+              }
+              return false;
+            },
+        // enabled: true,
+        //filter: true,
+            container: document.getElementById("config"),
+          }
+                                     }, options
+                             );
           var tags;
 
           // Initialize the network
@@ -484,7 +524,7 @@
           globalNetwork = new vis.Network(document.getElementById("global-network"),
                                           {nodes: view,
                                            edges: edgeDataset},
-                                          options);
+                                          configoptions);
 
           var tempNetwork = new vis.Network(document.getElementById("temp-network"),
                                             {nodes: nodeDataset,
@@ -497,6 +537,10 @@
           globalNetwork.on("hoverNode", onNodeHover);
           globalNetwork.on("blurNode", onNodeBlur);
 
+          globalNetwork.on("stabilizationIterationsDone", function () {
+              network.setOptions( { physics: false } );
+          });
+          
           $('#colormode-checkbox').change()
 
           function onStabilized () {
@@ -509,6 +553,7 @@
 
           var currentNode;
           var preview = false;
+          var tweaks = false;
 
           var currentBuffer;
           var oldCurrentBufferData = "";
@@ -769,6 +814,8 @@
               $("#global-network").css("display", "none");
               $("#buffer-network").css("display", "block");
               $("#toggle-list-type-button").css("display", "none");
+              $("#toggle-tweaks").css("display","none");
+              $("#config").css("display", "none");
               if (currentNode) {
                   drawBufferNetwork();
               }
@@ -783,6 +830,8 @@
               $("#dropdownfilters").css("display", "none");
               $("#fileframe").css("display", "block");
               $("#toggle-list-type-button").css("display", "none");
+              $("#toggle-tweaks").css("display","none");
+              $("#config").css("display", "none");
           });
           $("#toggle-preview").click(function() {
               if (preview) {
@@ -791,6 +840,17 @@
               } else {
                   preview = true;
                   $("#toggle-preview").text("Disable Preview");
+              }
+          });
+          $("#toggle-tweaks").click(function() {
+              if (tweaks) {
+                  tweaks = false;
+                  $("#toggle-tweaks").text("Show Tweaks");
+                  $("#config").css("display", "none");
+              } else {
+                  tweaks = true;
+                  $("#toggle-tweaks").text("Hide Tweaks");
+                  $("#config").css("display", "block");
               }
           });
           $("#inputdistance").on("input", drawBufferNetwork);

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -181,6 +181,22 @@ In the first case options are applied to all edges."
           (list :tag "Argument to json-encode")
           (function :tag "Custom function")))
 
+(defcustom org-roam-server-extra-cite-edge-options nil
+  "Additional options for edges created through citations with org-roam-bibtex.
+A list suitable for `json-encode', e.g. (list (cons 'width 3)),
+or a custom function with one argument EDGE producing such a list.
+In the first case options are applied to all cite-edges."
+  :group 'org-roam-server
+  :type '(choice
+          (list :tag "Argument to json-encode")
+          (function :tag "Custom function")))
+
+(defcustom org-roam-server-cite-edge-dashes nil
+  "When non-nil, changes the edges created through org-roam-bibtex citations to dashes
+to more easily distinguish them from other edges."
+  :group 'org-roam-server
+  :type 'boolean)
+
 (defcustom org-roam-server-default-include-filters "null"
   "Options to set default include filters, in JSON format.
 e.g. (json-encode (list (list (cons 'id \"test\") (cons 'parent \"tags\"))))
@@ -371,9 +387,19 @@ This is added as a hook to `org-capture-after-finalize-hook'."
       (dolist (edge edges-cites)
         (let* ((title-source (org-roam--path-to-slug (elt edge 0)))
                (title-target (org-roam--path-to-slug (elt edge 1))))
-          (push (remove nil (list (cons 'from title-source)
+          (push (remove nil (append (list (cons 'from title-source)
                                   (cons 'to title-target)
-                                  (cons 'arrows org-roam-server-network-arrows)))
+                                  (cons 'arrows org-roam-server-network-arrows)
+                                  (cons 'dashes org-roam-server-cite-edge-dashes))
+                                    (pcase org-roam-server-extra-cite-edge-options
+                                      ('nil nil)
+                                      ((pred functionp)
+                                       (funcall org-roam-server-extra-cite-edge-options edge))
+                                      ((pred listp)
+                                       org-roam-server-extra-cite-edge-options)
+                                      (wrong-type
+                                       (error "Wrong type of org-roam-server-extra-cite-edge-options: %s"
+                                              wrong-type)))))
                 (cdr (elt graph 1)))))
       (json-encode graph))))
 

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -192,7 +192,8 @@ In the first case options are applied to all cite-edges."
           (function :tag "Custom function")))
 
 (defcustom org-roam-server-cite-edge-dashes nil
-  "When non-nil, changes the edges created through org-roam-bibtex citations to dashes
+  "When non-nil, change citation edges to dashes.
+Changes edges that are created through org-roam-bibtex citations
 to more easily distinguish them from other edges."
   :group 'org-roam-server
   :type 'boolean)

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -390,7 +390,8 @@ This is added as a hook to `org-capture-after-finalize-hook'."
           (push (remove nil (append (list (cons 'from title-source)
                                   (cons 'to title-target)
                                   (cons 'arrows org-roam-server-network-arrows)
-                                  (cons 'dashes org-roam-server-cite-edge-dashes))
+                                (if org-roam-server-cite-edge-dashes
+                                  (cons 'dashes org-roam-server-cite-edge-dashes)) nil)
                                     (pcase org-roam-server-extra-cite-edge-options
                                       ('nil nil)
                                       ((pred functionp)

--- a/org-roam-server.el
+++ b/org-roam-server.el
@@ -390,8 +390,8 @@ This is added as a hook to `org-capture-after-finalize-hook'."
           (push (remove nil (append (list (cons 'from title-source)
                                   (cons 'to title-target)
                                   (cons 'arrows org-roam-server-network-arrows)
-                                (if org-roam-server-cite-edge-dashes
-                                  (cons 'dashes org-roam-server-cite-edge-dashes)) nil)
+                                (when org-roam-server-cite-edge-dashes
+                                  (cons 'dashes org-roam-server-cite-edge-dashes)))
                                     (pcase org-roam-server-extra-cite-edge-options
                                       ('nil nil)
                                       ((pred functionp)


### PR DESCRIPTION
Solves #147 to bring the same level of edge customization to the citation edges, plus provides a simpler variable which makes the citation edges dashes to further visually distinguish them from "normal".

```emacs-lisp
(setq org-roam-server-cite-edge-dashes t
      org-roam-server-extra-cite-edge-options (list (cons 'width 3))
```
yield what you would expect:

![image](https://user-images.githubusercontent.com/21983833/116694566-f6813a80-a9ae-11eb-87f8-e4286af6220c.png)


Should not break anything, as the code is exactly the same as the one for edges.